### PR TITLE
split out test into separate function

### DIFF
--- a/tests/all/test_builder.rs
+++ b/tests/all/test_builder.rs
@@ -703,22 +703,6 @@ fn test_vector_convert_ops() {
     builder.build_return(Some(&casted_vec));
     assert!(fn_value.verify(true));
 
-    #[llvm_versions(8.0..=latest)]
-    {
-    // Here we're building a function that takes in a <3 x i8> (signed) and returns it casted to and from a <3 x i8> (unsigned)
-    let fn_type = int8_vec_type.fn_type(&[int8_vec_type.into()], false);
-    let fn_value = module.add_function("test_int_vec_cast", fn_type, None);
-    let entry = context.append_basic_block(fn_value, "entry");
-    let builder = context.create_builder();
-
-    builder.position_at_end(entry);
-    let in_vec = fn_value.get_first_param().unwrap().into_vector_value();
-    let casted_vec = builder.build_int_cast_sign_flag(in_vec, int8_vec_type, true, "casted_vec");
-    let _uncasted_vec = builder.build_int_cast_sign_flag(casted_vec, int8_vec_type, true, "uncasted_vec");
-    builder.build_return(Some(&casted_vec));
-    assert!(fn_value.verify(true));
-    }
-
     // Here we're building a function that takes in a <3 x f32> and returns it casted to and from a <3 x f16>
     let fn_type = float16_vec_type.fn_type(&[float32_vec_type.into()], false);
     let fn_value = module.add_function("test_float_vec_cast", fn_type, None);
@@ -743,6 +727,29 @@ fn test_vector_convert_ops() {
     let casted_vec = builder.build_float_to_signed_int(in_vec, int32_vec_type, "casted_vec");
     let _uncasted_vec = builder.build_signed_int_to_float(casted_vec, float32_vec_type, "uncasted_vec");
     builder.build_return(Some(&casted_vec));
+    assert!(fn_value.verify(true));
+}
+
+#[llvm_versions(8.0..=latest)]
+#[test]
+fn test_vector_convert_ops_respect_target_signedness() {
+    let context = Context::create();
+    let module = context.create_module("test");
+    let int8_vec_type = context.i8_type().vec_type(3);
+
+    // Here we're building a function that takes in a <3 x i8> (signed) and returns it casted to and from a <3 x i8> (unsigned)
+    let fn_type = int8_vec_type.fn_type(&[int8_vec_type.into()], false);
+    let fn_value = module.add_function("test_int_vec_cast", fn_type, None);
+    let entry = context.append_basic_block(fn_value, "entry");
+    let builder = context.create_builder();
+
+    builder.position_at_end(entry);
+    let in_vec = fn_value.get_first_param().unwrap().into_vector_value();
+    let casted_vec = builder.build_int_cast_sign_flag(in_vec, int8_vec_type, true, "casted_vec");
+    let _uncasted_vec =
+        builder.build_int_cast_sign_flag(casted_vec, int8_vec_type, true, "uncasted_vec");
+    builder.build_return(Some(&casted_vec));
+
     assert!(fn_value.verify(true));
 }
 


### PR DESCRIPTION
inkwell has a pretty low/old minimum supported rust version, and annotating a block with a `cfg` is not stable in that version. This should fix the CI failure